### PR TITLE
[WIP] Feature: Custom Character Sort Order

### DIFF
--- a/AlterEgo.lua
+++ b/AlterEgo.lua
@@ -43,6 +43,7 @@ AlterEgo.constants = {
         {value = "ilvl.desc",   text = "Item Level (Highest)"},
         {value = "class.asc",   text = "Class (A-Z)"},
         {value = "class.desc",  text = "Class (Z-A)"},
+        {value = "custom",  text = "Custom"},
     }
 }
 

--- a/Database.lua
+++ b/Database.lua
@@ -3,6 +3,7 @@ local defaultDB = {
     global = {
         weeklyReset = 0,
         characters = {},
+        characterCustomSortOrder = {},
         minimap = {
             minimapPos = 195,
             hide = false,
@@ -444,7 +445,10 @@ function AlterEgo:GetCharacters(unfiltered)
             return a.info.class.name < b.info.class.name
         elseif self.db.global.sorting == "class.desc" then
             return a.info.class.name > b.info.class.name
+        elseif self.db.global.sorting == "custom" then
+            return self.db.global.characterCustomSortOrder[a.GUID] < self.db.global.characterCustomSortOrder[b.GUID]
         end
+
         return a.lastUpdate > b.lastUpdate
     end)
 
@@ -662,6 +666,12 @@ function AlterEgo:UpdateCharacterInfo()
         character.equipment = {}
     else
         wipe(character.equipment or {})
+    end
+
+    -- Place character into db.global.characterCustomSortOrder if it doesn't exist already
+    if self.db.global.characterCustomSortOrder[character.GUID] == nil then
+        -- Ensure that any new character added to the DB is forced to the end of the sort order
+        self.db.global.characterCustomSortOrder[character.GUID] = 999
     end
 
     local upgradePattern = ITEM_UPGRADE_TOOLTIP_FORMAT_STRING


### PR DESCRIPTION
Changes:

* Add new DB table `characterCustomSortOrder` that acts as a persistent child table for a custom sort orders, with the join column being the character GUID 
  * I'm assuming this is more constant than the character's name - I've heard anecdotally that this changes on server or race transfer, so this might not be perfect
* Add new dropdown value "Custom" in global sort options
* Create new `characterCustomSortOrder` entry for each character in `AlterEgo:UpdateCharacterInfo` if val doesn't exist, and force it to the end of the sort order
* Create extensible functionality for "Moveable" elements within `AlterEgo:CreateCharacterColumn`, so as to not just attach it to a singular Frame or Character column