### PR TITLE
Coloring capped currencies and adding key cap

### DIFF
--- a/Database.lua
+++ b/Database.lua
@@ -351,14 +351,14 @@ Data.currencies = {
   {seasonID = 13, seasonDisplayID = 1, id = 2917, currencyType = "crest"},                    -- Gilded
   {seasonID = 13, seasonDisplayID = 1, id = 3008, currencyType = "upgrade"},                  -- Valorstones
   {seasonID = 13, seasonDisplayID = 1, id = 2813, currencyType = "catalyst"},                 -- Catalyst
-  {seasonID = 13, seasonDisplayID = 1, id = 3028, currencyType = "delve"},                    -- Restored Coffer key
+  {seasonID = 13, seasonDisplayID = 1, id = 3028, currencyType = "delve", capQuests = { 84736, 84737, 84738, 84739 } },                    -- Restored Coffer key
   {seasonID = 14, seasonDisplayID = 2, id = 3110, currencyType = "crest"},                    -- Gilded
   {seasonID = 14, seasonDisplayID = 2, id = 3109, currencyType = "crest"},                    -- Runed
   {seasonID = 14, seasonDisplayID = 2, id = 3108, currencyType = "crest"},                    -- Carved
   {seasonID = 14, seasonDisplayID = 2, id = 3107, currencyType = "crest"},                    -- Weathered
   {seasonID = 14, seasonDisplayID = 2, id = 3008, currencyType = "upgrade"},                  -- Valorstones
   {seasonID = 14, seasonDisplayID = 2, id = 3116, currencyType = "catalyst"},                 -- Catalyst
-  {seasonID = 14, seasonDisplayID = 2, id = 3028, currencyType = "delve"},                    -- Restored Coffer key
+  {seasonID = 14, seasonDisplayID = 2, id = 3028, currencyType = "delve", capQuests = { 84736, 84737, 84738, 84739 } },                    -- Restored Coffer key
 }
 
 Data.cache = {
@@ -1023,10 +1023,25 @@ function Data:UpdateCurrencies()
     if not currency then return end
     currency.id = dataCurrency.id
     currency.currencyType = dataCurrency.currencyType
-    if dataCurrency.itemID then
+
+		if dataCurrency.itemID then
       currency.quantity = C_Item.GetItemCount(dataCurrency.itemID, true)
       currency.iconFileID = C_Item.GetItemIconByID(dataCurrency.itemID) or 0
     end
+
+		if dataCurrency.capQuests ~= nil then
+			currency.useTotalEarnedForMaxQty = true
+			currency.totalEarned = 0
+			currency.maxQuantity = #dataCurrency.capQuests
+
+			for index, questId in ipairs(dataCurrency.capQuests) do
+				local completed = C_QuestLog.IsQuestFlaggedCompleted(questId)
+				if completed then
+					currency.totalEarned = currency.totalEarned + 1
+				end
+			end
+		end
+
     table.insert(character.currencies, currency)
   end)
 end

--- a/Interface.lua
+++ b/Interface.lua
@@ -440,9 +440,13 @@ function UI:GetCharacterInfo(unfiltered)
               local icon = CreateSimpleTextureMarkup(characterCurrency.iconFileID or [[Interface\Icons\INV_Misc_QuestionMark]])
               local currencyLabel = format("%s %s", icon, characterCurrency.maxQuantity > 0 and math.min(characterCurrency.quantity, characterCurrency.maxQuantity) or characterCurrency.quantity)
               local currencyValue = ""
+							local currencyColor = WHITE_FONT_COLOR
               if characterCurrency.useTotalEarnedForMaxQty then
                 if characterCurrency.maxQuantity > 0 then
                   currencyValue = format("%d/%d", characterCurrency.totalEarned, characterCurrency.maxQuantity)
+									if characterCurrency.totalEarned >= characterCurrency.maxQuantity then
+										currencyColor = GREEN_FONT_COLOR
+									end
                 else
                   currencyValue = "No limit"
                 end
@@ -452,6 +456,8 @@ function UI:GetCharacterInfo(unfiltered)
               table.insert(characterCurrencies, {
                 currencyLabel,
                 currencyValue,
+								WHITE_FONT_COLOR,
+								currencyColor
               })
             end
           end)
@@ -460,7 +466,12 @@ function UI:GetCharacterInfo(unfiltered)
           GameTooltip:AddLine(" ")
           GameTooltip:AddDoubleLine("Currencies:", "Maximum:")
           addon.Utils:TableForEach(characterCurrencies, function(characterCurrency)
-            GameTooltip:AddDoubleLine(characterCurrency[1], characterCurrency[2], 1, 1, 1, 1, 1, 1)
+            GameTooltip:AddDoubleLine(
+							characterCurrency[1],
+							characterCurrency[2],
+							characterCurrency[3].r, characterCurrency[3].g, characterCurrency[3].b,
+							characterCurrency[4].r, characterCurrency[4].g, characterCurrency[4].b
+						)
           end)
         end
         if character.lastUpdate ~= nil then

--- a/Types.lua
+++ b/Types.lua
@@ -43,6 +43,7 @@
 ---@field seasonID number
 ---@field seasonDisplayID number
 ---@field currencyType AE_CurrencyType
+---@field capQuests number[]?
 
 ---@class AE_CharacterCurrency : CurrencyInfo
 ---@field id number


### PR DESCRIPTION
First change, a simple one: 
making capped resources use the GREEN color text to make them stand out more.

Second change, a more insteresting one:
there is no hard cap for chest keys, but there is a 'soft weekly cap' based on quest progress. I updated the resources table to accept those cap quest list, and then check that progress on the update flow.

![image](https://github.com/user-attachments/assets/6abe0c38-5282-446d-a909-3f070110a9e1)
