### PR TITLE
Feature : best in slot tracker

### DIFF
--- a/AlterEgo.lua
+++ b/AlterEgo.lua
@@ -83,6 +83,7 @@ function Core:OnEnable()
     }, 3, function()
       addon.Data:UpdateCharacterInfo()
       addon.Data:UpdateEquipment()
+      addon.Data:UpdateBisProgressForCharacter()
     end
   )
   self:RegisterBucketEvent(

--- a/AlterEgo.lua
+++ b/AlterEgo.lua
@@ -178,6 +178,10 @@ function Core:OnEnable()
       addon.Data:UpdateDB()
     end
   )
+
+  self:RegisterEvent("GET_ITEM_INFO_RECEIVED", function(event, itemId)
+    addon.Items:RegisterItem(itemId)
+  end)
   self:CheckGameData()
 end
 

--- a/AlterEgo.toc
+++ b/AlterEgo.toc
@@ -41,3 +41,6 @@ Database.lua
 Interface.lua
 AlterEgo.lua
 Items.lua
+Items\LiberationOfUndermine.lua
+Items\NerubArPalace.lua
+Items\TwwS2.lua

--- a/AlterEgo.toc
+++ b/AlterEgo.toc
@@ -40,3 +40,4 @@ Table.lua
 Database.lua
 Interface.lua
 AlterEgo.lua
+Items.lua

--- a/Database.lua
+++ b/Database.lua
@@ -1299,7 +1299,7 @@ function Data:UpdateBisItem(characterGuid, slotId, item)
     character.bis[slotId] = nil
   else
     character.bis[slotId] = {
-      item = item,
+      itemId = item.id,
       progress = 0,
     }
   end
@@ -1309,7 +1309,6 @@ function Data:UpdateBisItem(characterGuid, slotId, item)
 end
 
 function Data:UpdateBisProgressForCharacter(character)
-
   if not character then
     character = self:GetCharacter()
   end
@@ -1324,10 +1323,11 @@ function Data:UpdateBisProgressForCharacter(character)
 
     local itemId = addon.Items:ParseIdFromLink(equipment.itemLink)
 
-    if bis.item.id ~= itemId then
+    if bis.itemId ~= itemId then
       bis.progress = 0
     else
-      local itemRange = bis.item.maxLevel - addon.Items.minItemLevel
+      local item = addon.Items:GetItemData(bis.itemId)
+      local itemRange = item.maxLevel - addon.Items.minItemLevel
       local itemProgress = equipment.itemLevel - addon.Items.minItemLevel
 
       bis.progress = tonumber(string.format("%.0f",math.min(100, math.max(0, (itemProgress / itemRange) * 100))))

--- a/Interface.lua
+++ b/Interface.lua
@@ -2217,11 +2217,12 @@ function UI:RenderAffixWindow()
 end
 
 function UI:RenderEquipmentWindow()
-  local tableWidth = 610
+  local tableWidth = 890
   local tableHeight = 0
   local rowHeight = 22
 
-  if not self.equipmentWindow then
+  local equipmentWindow = self.equipmentWindow
+  if not equipmentWindow then
     self.equipmentWindow = addon.Window:New({
       name = "Equipment",
       title = "Character",
@@ -2233,6 +2234,8 @@ function UI:RenderEquipmentWindow()
     self.equipmentWindow:SetScript("OnShow", function()
       self:RenderEquipmentWindow()
     end)
+
+    equipmentWindow = self.equipmentWindow
   end
 
   if not self.equipmentWindow:IsVisible() then
@@ -2252,6 +2255,7 @@ function UI:RenderEquipmentWindow()
       {width = 280},
       {width = 80, align = "CENTER"},
       {width = 150},
+      {width = 280},
     },
     rows = {
       {
@@ -2260,7 +2264,8 @@ function UI:RenderEquipmentWindow()
           {text = "Item",          backgroundColor = {r = 0, g = 0, b = 0, a = 0.3}},
           {text = "iLevel",        backgroundColor = {r = 0, g = 0, b = 0, a = 0.3}},
           {text = "Upgrade Level", backgroundColor = {r = 0, g = 0, b = 0, a = 0.3}},
-        },
+          {text = "Best In Slot",  backgroundColor = {r = 0, g = 0, b = 0, a = 0.3}},
+        }
       },
     },
   }
@@ -2277,6 +2282,7 @@ function UI:RenderEquipmentWindow()
       end
     end
 
+    
     ---@type AE_TableDataRow
     local row = {
       columns = {
@@ -2303,6 +2309,37 @@ function UI:RenderEquipmentWindow()
         },
         {text = WrapTextInColorCode(tostring(item.itemLevel), select(4, GetItemQualityColor(item.itemQuality)))},
         {text = upgradeLevel},
+        {
+          text = "Click to select item",
+          onClick = function(columnFrame)
+            print('--------------------------------')
+            local bisItemDropdown = addon.Utils:CreateBisItemDropdown(columnFrame, character, item.itemSlotID)
+
+            if not bisItemDropdown then
+              return
+            end
+
+            print("bisItemDropdown", bisItemDropdown:GetName())
+
+            local openedDropdown = self.equipmentWindow.bisItemDropdown
+            print("openedDropdown", openedDropdown)
+            if openedDropdown ~= nil then
+              print("openedDropdown", openedDropdown:GetName())
+              openedDropdown:Hide()
+
+              if openedDropdown:GetName() == bisItemDropdown:GetName() then
+                print("openedDropdown == bisItemDropdown")
+                self.equipmentWindow.bisItemDropdown = nil
+                return
+              end
+            end
+
+            print("Show bisItemDropdown")
+            
+            bisItemDropdown:Show()
+            self.equipmentWindow.bisItemDropdown = bisItemDropdown
+          end,
+        },
       },
     }
     table.insert(data.rows, row)

--- a/Interface.lua
+++ b/Interface.lua
@@ -2300,9 +2300,14 @@ function UI:RenderEquipmentWindow()
     end
 
     local bisText = "Click to select item"
-    local bis = character.bis[item.itemSlotID]
-    if bis then
-      bisText = "|T" .. bis.item.texture .. ":0|t " .. bis.item.link .. " (" .. bis.progress .. "%)"
+    local hasBis = character.bis[item.itemSlotID]
+    local bisItem = nil
+
+    if hasBis then
+      bisItem = addon.Items:GetItemData(hasBis.itemId)
+      if bisItem then
+        bisText = "|T" .. bisItem.texture .. ":0|t " .. bisItem.link .. " (" .. hasBis.progress .. "%)"
+      end
     end
 
     ---@type AE_TableDataRow
@@ -2334,16 +2339,16 @@ function UI:RenderEquipmentWindow()
         {
           text = bisText,
           onEnter = function(columnFrame)
-            if bis then
+            if bisItem then
               GameTooltip:SetOwner(columnFrame, "ANCHOR_RIGHT")
-              GameTooltip:SetHyperlink(bis.item.link)
+              GameTooltip:SetHyperlink(bisItem.link)
               GameTooltip:AddLine(" ")
-              GameTooltip:AddLine("To loot on: " .. bis.item.bossName .. " - " .. bis.item.instanceName)
+              GameTooltip:AddLine(bisItem.bossName .. " - " .. bisItem.instanceName)
               GameTooltip:Show()
             end
           end,
           onLeave = function()
-            if bis then
+            if bisItem then
               GameTooltip:Hide()
             end
           end,

--- a/Interface.lua
+++ b/Interface.lua
@@ -2294,7 +2294,6 @@ function UI:RenderEquipmentWindow()
       end
     end
 
-    
     ---@type AE_TableDataRow
     local row = {
       columns = {
@@ -2389,7 +2388,6 @@ function UI:RenderBisItemDropdown(columnFrame, character, slotID)
       rows = {},
     }
 
-    print("showAllItems", addon.Items.showAllItems)
     local classId = nil
     if false == addon.Items.showAllItems then
       classId = character.info.class.id
@@ -2409,6 +2407,9 @@ function UI:RenderBisItemDropdown(columnFrame, character, slotID)
           onLeave = function()
             GameTooltip:Hide()
           end,
+          onClick = function()
+            addon.Items:GetItemLevelFromTooltip(item.link)
+          end
       }}})
     end
 

--- a/Items.lua
+++ b/Items.lua
@@ -1,0 +1,185 @@
+local addonName = select(1, ...)
+local addon = select(2, ...)
+
+local Items = {
+    itemData = {},
+    unsavedItemData = {},
+    instanceData = {},
+    showAllItems = false,
+    maxItemLevel = 678, -- TWW S2
+    invTypes = {
+        [1] = "INVTYPE_HEAD",
+        [2] = "INVTYPE_NECK",
+        [3] = "INVTYPE_SHOULDER",
+        [4] = "INVTYPE_BODY",
+        [5] = {"INVTYPE_CHEST", "INVTYPE_ROBE"},
+        [6] = "INVTYPE_WAIST",
+        [7] = "INVTYPE_LEGS",
+        [8] = "INVTYPE_FEET",
+        [9] = "INVTYPE_WRIST",
+        [10] = "INVTYPE_HAND",
+        [11] = "INVTYPE_FINGER",
+        [12] = "INVTYPE_FINGER",
+        [13] = "INVTYPE_TRINKET",
+        [14] = "INVTYPE_TRINKET",
+        [15] = "INVTYPE_CLOAK",
+        [16] = {"INVTYPE_WEAPON", "INVTYPE_2HWEAPON", "INVTYPE_WEAPONMAINHAND", "INVTYPE_RANGED", "INVTYPE_RANGEDRIGHT", "INVTYPE_NON_EQUIP"},
+        [17] = {"INVTYPE_WEAPONOFFHAND", "INVTYPE_SHIELD", "INVTYPE_WEAPON", "INVTYPE_HOLDABLE", "INVTYPE_NON_EQUIP"},
+        --[18] = {"INVTYPE_RANGED", "INVTYPE_THROWN", "INVTYPE_RANGEDRIGHT", "INVTYPE_RELIC"}
+      }
+}
+addon.Items = Items
+
+function Items:RegisterInstance(instanceId, difficulty, bonuses)
+    local info = C_Map.GetMapInfo(instanceId)
+    if not info then
+        assert(false, "Instance " .. instanceId .. " not found")
+        return
+    end
+
+    self.instanceData[info.mapID] = {
+        id = info.mapID,
+        name = info.name,
+        difficulty = difficulty or 1,
+        bonuses = bonuses
+    }
+
+    print("Instance " .. info.name .. " registered")
+
+    return self.instanceData[info.mapID]
+end
+
+-- @param #object instance The instance to register the items for
+--      instanceId The difficulty of the instance
+--      infoId Encounter info id
+--      items The items that drop from the boss
+function Items:RegisterBossLoots(bossLoots)
+    local instance = self.instanceData[bossLoots.instanceId]
+    if not instance then
+        DevTools_Dump(bossLoots)
+        assert(false, "Instance " .. (bossLoots.instanceId or "nil") .. " not found")
+        return
+    end
+
+    ---@diagnostic disable-next-line: undefined-global
+    local bossName = EJ_GetEncounterInfo(bossLoots.infoId)
+    if not bossName then
+        assert(false, "Encounter " .. bossLoots.infoId .. " not found")
+        return
+    end
+
+    for _, itemId in ipairs(bossLoots.items) do
+        if not self.itemData[itemId] then
+            local itemData = self:GetItemData(itemId, instance, bossName)
+            if itemData then
+                self.itemData[itemId] = itemData
+            else
+                self.unsavedItemData[itemId] = {
+                    instanceId = instance.id,
+                    infoId = bossLoots.infoId
+                }
+            end
+        end
+    end
+end
+
+function Items:GetItemData(itemId, instance, bossName)
+    local itemString = self:GetItemString(itemId, instance.difficulty, instance.bonuses)
+    local _, link, _, _, _, _, _, _, invType, texture = C_Item.GetItemInfo(itemString)
+    if link then
+        -- TODO: use the new GetDetailedItemLevelInfo after 11.1.5
+        local actualLevel = C_Item.GetDetailedItemLevelInfo(link)
+        local maxLevel = self:GetItemLevelFromTooltip(link, actualLevel)
+
+        self.itemData[itemId] = {
+            link = link,
+            invType = invType,
+            texture = texture,
+            instanceName = instance.name,
+            bossName = bossName,
+            maxLevel = maxLevel
+        }
+
+        return self.itemData[itemId]
+    end
+
+    return nil
+end
+
+function Items:RegisterItem(itemId)
+    local item = self.unsavedItemData[itemId]
+    if item then
+        local instance = self.instanceData[item.instanceId]
+        local bossName = EJ_GetEncounterInfo(item.infoId)
+        if instance == nil or bossName == nil then
+            return
+        end
+
+        local itemData = self:GetItemData(itemId, instance, bossName)
+
+        if itemData then
+            self.itemData[itemId] = itemData
+            self.unsavedItemData[itemId] = nil
+        end
+    end
+end
+
+local upgradePattern = ITEM_UPGRADE_TOOLTIP_FORMAT_STRING
+upgradePattern = upgradePattern:gsub("%%d", "%%s")
+upgradePattern = upgradePattern:format("(.*)", "(%d+)", "(%d+)")
+print(upgradePattern)
+
+function Items:GetItemLevelFromTooltip(link, actualLevel)
+    local scanTooltip = CreateFrame("GameTooltip", "AlterEgoScanTooltip", UIParent, "GameTooltipTemplate")
+    scanTooltip:SetOwner(UIParent, "ANCHOR_NONE")
+    scanTooltip:SetHyperlink(link)
+
+    local maxLevel = actualLevel
+    for i = 2, scanTooltip:NumLines() do 
+        local line = _G["AlterEgoScanTooltipTextLeft" .. i]:GetText()
+        if line then
+            local match, _, uTrack, uLevel, uMax = line:find(upgradePattern)
+            if match then
+                -- upgradable item, set to max level
+                return actualLevel < self.maxItemLevel and self.maxItemLevel or actualLevel
+            end
+        end
+    end
+
+    return maxLevel
+end
+
+function Items:GetItemsBySlot(slotId, classId)
+    local items = {}
+    for item, data in pairs(self.itemData) do
+        if data.invType == self.invTypes[slotId] then
+            if classId == nil then
+                items[item] = data
+            else
+                local doesItemContainClass = C_Item.DoesItemContainSpec(item, classId)
+                if doesItemContainClass then
+                    items[item] = data
+                end
+            end
+        end
+    end
+    return items
+end
+
+--item:itemId:enchantId:gemId1:gemId2:gemId3:gemId4:suffixId:uniqueId:linkLevel:specializationID:upgradeId:instanceDifficultyId:numBonusIds:bonusId1:bonusId2:upgradeValue
+function Items:GetItemString(itemId, difficulty, bonuses)
+    local baseItemString = ("item:%d"):format(itemId)
+    local enchantString = ":::::::::::"
+    local difficultyString = ("%d:"):format(difficulty)
+    local nbBonuses = ("%d:"):format(#bonuses)
+    local bonusString = "";
+    for _, bonus in ipairs(bonuses) do
+        bonusString = ("%s%d:"):format(bonusString, bonus)
+    end
+    for i = #bonuses + 1, 5 do
+        bonusString = bonusString .. ":"
+    end
+
+    local itemString = ("%s%s%s%s%s"):format(baseItemString, enchantString, difficultyString, nbBonuses, bonusString)
+    return itemString
+end

--- a/Items.lua
+++ b/Items.lua
@@ -8,6 +8,7 @@ local Items = {
     showAllItems = false,
     minItemLevel = 623, -- TWW S2 : veteran 1/8
     maxItemLevel = 678, -- TWW S2 : mythic 6/6
+    maxCraftItemLevel = 675, -- TWW S2 : max craft item level
     invTypes = {
         [1] = "INVTYPE_HEAD",
         [2] = "INVTYPE_NECK",
@@ -68,7 +69,7 @@ function Items:RegisterBossLoots(bossLoots)
 
     for _, itemId in ipairs(bossLoots.items) do
         if not self.itemData[itemId] then
-            local itemData = self:GetItemData(itemId, instance, bossName)
+            local itemData = self:ComputeItemData(itemId, instance, bossName)
             if itemData then
                 self.itemData[itemId] = itemData
             else
@@ -81,7 +82,7 @@ function Items:RegisterBossLoots(bossLoots)
     end
 end
 
-function Items:GetItemData(itemId, instance, bossName)
+function Items:ComputeItemData(itemId, instance, bossName)
     local itemString = self:GetItemString(itemId, instance.difficulty, instance.bonuses)
     local name, link, _, _, _, _, _, _, invType, texture = C_Item.GetItemInfo(itemString)
     if link then
@@ -106,6 +107,10 @@ function Items:GetItemData(itemId, instance, bossName)
     return nil
 end
 
+function Items:GetItemData(itemId)
+    return self.itemData[itemId]
+end
+
 function Items:ParseIdFromLink(link)
     local itemId = 0
     local _, _, id = link:find("item:(%d+)")
@@ -121,12 +126,14 @@ function Items:RegisterItem(itemId)
     local item = self.unsavedItemData[itemId]
     if item then
         local instance = self.instanceData[item.instanceId]
+
+        ---@diagnostic disable-next-line: undefined-global
         local bossName = EJ_GetEncounterInfo(item.infoId)
         if instance == nil or bossName == nil then
             return
         end
 
-        local itemData = self:GetItemData(itemId, instance, bossName)
+        local itemData = self:ComputeItemData(itemId, instance, bossName)
 
         if itemData then
             self.itemData[itemId] = itemData

--- a/Items.lua
+++ b/Items.lua
@@ -55,7 +55,6 @@ end
 function Items:RegisterBossLoots(bossLoots)
     local instance = self.instanceData[bossLoots.instanceId]
     if not instance then
-        DevTools_Dump(bossLoots)
         assert(false, "Instance " .. (bossLoots.instanceId or "nil") .. " not found")
         return
     end
@@ -71,9 +70,6 @@ function Items:RegisterBossLoots(bossLoots)
         if not self.itemData[itemId] then
             local itemData = self:GetItemData(itemId, instance, bossName)
             if itemData then
-                if itemId == 221122 then
-                    DevTools_Dump(itemData)
-                end
                 self.itemData[itemId] = itemData
             else
                 self.unsavedItemData[itemId] = {

--- a/Items/LiberationOfUndermine.lua
+++ b/Items/LiberationOfUndermine.lua
@@ -1,0 +1,347 @@
+local LiberationOfUndermine = LibStub("AceAddon-3.0"):GetAddon("AlterEgo"):NewModule("LiberationOfUndermine")
+local tocVersion = select(1, GetBuildInfo())
+
+if tocVersion <= "11.0.2" then
+    return
+end
+
+---@class AE_Addon
+local addon = select(2, ...)
+
+function LiberationOfUndermine:OnEnable()
+
+    print("LiberationOfUndermine:OnEnable")
+    local instance = addon.Items:RegisterInstance(2406, 6, {3524})
+
+    ----- Strolch and the Gang Keepers
+    local bossLoot = {
+        infoId = 2639,
+        instanceId = instance.id,
+        items = {
+            223048, --Plans: Draining Stiletto
+            228892, --Greasemonkey's Gear Shift
+            231268, --Blast Rage Machete
+            228858, --Full Throttle Visage
+            228875, --Vandal's Skull Plate
+            228839, --Racing Flag of the Underground Circuit
+            228852, --Glory's Flame Blazer
+            228868, --Souped-Up Bracers
+            228861, --Tuning Tool Belt
+            228865, --Pit Doctor's Underskirt
+            228876, --Dragster's Final Meters
+            228862, --Shrapnel-Infused Sabatons
+            230197, --Gang Keeper's Spare Key
+            230019  --Strolch's Pit Whistle
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Cauldron of Carnage
+    bossLoot = {
+        infoId = 2640,
+        instanceId = instance.id,
+        items = {
+            228806, --High-Profit Bloody Galvite
+            228804, --Mystic Bloody Galvite
+            228803, --Dreadful Bloody Galvite
+            228805, --Venerated Bloody Galvite
+            228904, --Crowd Favorite
+            228900, --Arc of Tension
+            228890, --Superfan's Brawling Buzzer
+            228846, --Galvanic Graffiti Cuffs
+            228873, --Heavyweight Champion Belt
+            228856, --Battler's Victory Cord
+            228847, --Hot-Footed Heel Turners
+            228840, --Faded Championship Ring
+            230191, --Luminodo's Pilot Light
+            230190, --Torq's Big Red Button
+            -- Tier Set Hands
+            229236, --Warrior Hands
+            229245, --Paladin Hands
+            229254, --Death Knight Hands
+            229263, --Shaman Hands
+            229272, --Hunter Hands
+            229281, --Evoker Hands
+            229290, --Rogue Hands
+            229299, --Monk Hands
+            229308, --Druid Hands
+            229317, --Demon Hunter Hands
+            229326, --Warlock Hands
+            229335, --Priest Hands
+            229344  --Mage Hands
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Rik Resonance
+    bossLoot = {
+        infoId = 2641,
+        instanceId = instance.id,
+        items = {
+            228818, --High-Profit Polished Galvite
+            224435, --Pattern: Duskthread Lining
+            228816, --Mystic Polished Galvite
+            228815, --Dreadful Polished Galvite
+            228817, --Venerated Polished Galvite
+            228895, --Mixed Ignition Saber
+            228897, --Needle Storm Fireworks
+            231311, --Frontman's Wonder Wall
+            228841, --Semi-Enchanting Amulet
+            228857, --Underground Party Entry Band
+            228869, --Killer Queen's Wrist Snapper
+            228845, --Riot Diva's Sash
+            228874, --Rik's Strolling Boots
+            230194, --Hall Radio
+            -- Tier Set Shoulder
+            229233, --Warrior Shoulder
+            229242, --Paladin Shoulder
+            229251, --Death Knight Shoulder
+            229260, --Shaman Shoulder
+            229269, --Hunter Shoulder
+            229278, --Evoker Shoulder
+            229287, --Rogue Shoulder
+            229296, --Monk Shoulder
+            229305, --Druid Shoulder
+            229314, --Demon Hunter Shoulder
+            229323, --Warlock Shoulder
+            229332, --Priest Shoulder
+            229341  --Mage Shoulder
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Stix Bunkerwrecker
+    bossLoot = {
+        infoId = 2642,
+        instanceId = instance.id,
+        items = {
+            236687, --Explosive Hearthstone
+            228814, --High-Profit Rusty Galvite
+            228812, --Mystic Rusty Galvite
+            228811, --Dreadful Rusty Galvite
+            228813, --Venerated Rusty Galvite
+            228903, --Trash Diver
+            228896, --Stix's Metal Detector
+            228871, --Cleanup Crew's Waste Mask
+            228859, --Disinfected Scrap Hood
+            228849, --Waste Mech Compactor
+            228854, --Bilge Rat's Discarded Leggings
+            230189, --Scrap Maestro's Megamagnet
+            230026, --Scrapfield 9001
+            -- Tier Set Legs
+            229234, --Warrior Legs
+            229243, --Paladin Legs
+            229252, --Death Knight Legs
+            229261, --Shaman Legs
+            229270, --Hunter Legs
+            229279, --Evoker Legs
+            229288, --Rogue Legs
+            229297, --Monk Legs
+            229306, --Druid Legs
+            229315, --Demon Hunter Legs
+            229324, --Warlock Legs
+            229333, --Priest Legs
+            229342  --Mage Legs
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Cogmaster Lockstock
+    bossLoot = {
+        infoId = 2653,
+        instanceId = instance.id,
+        items = {
+            228802, --High-Profit Oiled Galvite
+            223097, --Pattern: Adrenaline Rush Buckle
+            228800, --Mystic Oiled Galvite
+            228799, --Dreadful Oiled Galvite
+            228801, --Venerated Oiled Galvite
+            228898, --Alpha Coil Thunder Staff
+            228894, --GIGADEATH Chain Blade
+            228844, --Test Pilot's Flight Sack
+            228884, --Test Subject's Shackles
+            228867, --Gravislick Grips
+            228882, --Refiner's Conveyor Belt
+            228888, --Rushed Beta Treads
+            230186, --Mr. Wakemaker
+            230193, --Master Lock-and-Stock
+            -- Tier Set Chest
+            229238, --Warrior Chest
+            229247, --Paladin Chest
+            229256, --Death Knight Chest
+            229265, --Shaman Chest
+            229274, --Hunter Chest
+            229283, --Evoker Chest
+            229292, --Rogue Chest
+            229301, --Monk Chest
+            229310, --Druid Chest
+            229319, --Demon Hunter Chest
+            229328, --Warlock Chest
+            229337, --Priest Chest
+            229346  --Mage Chest
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- The One-Armed Bandit
+    bossLoot = {
+        infoId = 2644,
+        instanceId = instance.id,
+        items = {
+            228810, --High-Profit Gilded Galvite
+            228808, --Mystic Gilded Galvite
+            228807, --Dreadful Gilded Galvite
+            228809, --Venerated Gilded Galvite
+            228905, --Gigabank Breaker
+            232526, --Gambleplate
+            231266, --Random Number Perforator
+            228906, --Management's Cheat Detector
+            228850, --Bargain Blouse
+            228885, --High Roller's Top
+            228886, --Coin-Operated Belt
+            228883, --Dubious Table Runners
+            228843, --Miniature Roulette Cauldron
+            230188, --Garbagio's Bottle Service
+            230027, --House of Cards
+            -- Tier Set Head
+            229235, --Warrior Head
+            229244, --Paladin Head
+            229253, --Death Knight Head
+            229262, --Shaman Head
+            229271, --Hunter Head
+            229280, --Evoker Head
+            229289, --Rogue Head
+            229298, --Monk Head
+            229307, --Druid Head
+            229316, --Demon Hunter Head
+            229325, --Warlock Head
+            229334, --Priest Head
+            229343  --Mage Head
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Mug'Zee, Security Chief
+    bossLoot = {
+        infoId = 2645,
+        instanceId = instance.id,
+        items = {
+            223094, --Design: Superior Jeweler's Setting
+            228902, --Cartel Member's Rejected Offer
+            232804, --Capo's Melted Knuckles
+            228901, --High Earner's Club
+            228893, --"Little Friend"
+            228842, --Gobfather's Gifted Jewelry
+            228870, --Underboss's Tailored Coat
+            228860, --Failed Enforcer's Shoulderguards
+            228851, --"Bulletproof" Chestguard
+            228878, --Made Man's Handcuffs
+            228863, --Enforcer's Long Fingers
+            228880, --Contract Killer's Holster
+            228853, --Hired Muscle's Legguards
+            228879, --Cemented Murloc Waders
+            230192, --Mug's Mummkrug
+            230199  --Zee's Gangster Hotline
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Chrome King Gallywix
+    bossLoot = {
+        infoId = 2646,
+        instanceId = instance.id,
+        items = {
+            236960, --A.S.M.R. Prototype
+            223144, --Formula: Weapon - Authority of the Depths
+            228819, --Overly Jeweled Curio
+            228891, --Capital Seizer
+            228899, --Gallywix's Iron Thumb
+            228889, --Titan of Industry
+            228848, --Darkmoon Cutthroat's Tricorne
+            228855, --Resourceful Spaulders
+            228864, --"Optimized" Cartel Uniform
+            228881, --Illegally Funded Bracers
+            228872, --Golden Handshakers
+            228877, --Coveted Dealer's Chain
+            228866, --Deep Pocketed Pantaloons
+            228887, --Cutthroat's Competition Stompers
+            231265, --The Jastor Diamond
+            230198, --Eye of Kezan
+            230029, --Chrombustion Bomb Suit
+            -- Token All Set Items
+            -- Tier Set Chest
+            229238, --Warrior Chest
+            229247, --Paladin Chest
+            229256, --Death Knight Chest
+            229265, --Shaman Chest
+            229274, --Hunter Chest
+            229283, --Evoker Chest
+            229292, --Rogue Chest
+            229301, --Monk Chest
+            229310, --Druid Chest
+            229319, --Demon Hunter Chest
+            229328, --Warlock Chest
+            229337, --Priest Chest
+            229346, --Mage Chest
+            -- Tier Set Hands
+            229236, --Warrior Hands
+            229245, --Paladin Hands
+            229254, --Death Knight Hands
+            229263, --Shaman Hands
+            229272, --Hunter Hands
+            229281, --Evoker Hands
+            229290, --Rogue Hands
+            229299, --Monk Hands
+            229308, --Druid Hands
+            229317, --Demon Hunter Hands
+            229326, --Warlock Hands
+            229335, --Priest Hands
+            229344, --Mage Hands
+            -- Tier Set Head
+            229235, --Warrior Head
+            229244, --Paladin Head
+            229253, --Death Knight Head
+            229262, --Shaman Head
+            229271, --Hunter Head
+            229280, --Evoker Head
+            229289, --Rogue Head
+            229298, --Monk Head
+            229307, --Druid Head
+            229316, --Demon Hunter Head
+            229325, --Warlock Head
+            229334, --Priest Head
+            229343, --Mage Head
+            -- Tier Set Legs
+            229234, --Warrior Legs
+            229243, --Paladin Legs
+            229252, --Death Knight Legs
+            229261, --Shaman Legs
+            229270, --Hunter Legs
+            229279, --Evoker Legs
+            229288, --Rogue Legs
+            229297, --Monk Legs
+            229306, --Druid Legs
+            229315, --Demon Hunter Legs
+            229324, --Warlock Legs
+            229333, --Priest Legs
+            229342, --Mage Legs
+            -- Tier Set Shoulder
+            229233, --Warrior Shoulder
+            229242, --Paladin Shoulder
+            229251, --Death Knight Shoulder
+            229260, --Shaman Shoulder
+            229269, --Hunter Shoulder
+            229278, --Evoker Shoulder
+            229287, --Rogue Shoulder
+            229296, --Monk Shoulder
+            229305, --Druid Shoulder
+            229314, --Demon Hunter Shoulder
+            229323, --Warlock Shoulder
+            229332, --Priest Shoulder
+            229341  --Mage Shoulder
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    print("LiberationOfUndermine:OnEnable end")
+end

--- a/Items/LiberationOfUndermine.lua
+++ b/Items/LiberationOfUndermine.lua
@@ -10,7 +10,6 @@ local addon = select(2, ...)
 
 function LiberationOfUndermine:OnEnable()
 
-    print("LiberationOfUndermine:OnEnable")
     local instance = addon.Items:RegisterInstance(2406, 6, {3524})
 
     ----- Strolch and the Gang Keepers
@@ -343,5 +342,4 @@ function LiberationOfUndermine:OnEnable()
     };
     addon.Items:RegisterBossLoots(bossLoot)
 
-    print("LiberationOfUndermine:OnEnable end")
 end

--- a/Items/NerubArPalace.lua
+++ b/Items/NerubArPalace.lua
@@ -9,10 +9,7 @@ end
 local addon = select(2, ...)
 
 
-print("Loading NerubArPalace")
-
 function NerubArPalace:OnEnable()
-    print("NerubArPalace:OnEnable")
     local instance = addon.Items:RegisterInstance(2292, 6, {3524})
     ----- Ulgrax the Devourer
     local bossLoot = {

--- a/Items/NerubArPalace.lua
+++ b/Items/NerubArPalace.lua
@@ -1,0 +1,273 @@
+local NerubArPalace = LibStub("AceAddon-3.0"):GetAddon("AlterEgo"):NewModule("NerubArPalace")
+local tocVersion = select(1, GetBuildInfo())
+
+if tocVersion <= "11.0.2" then
+    return
+end
+
+---@class AE_Addon
+local addon = select(2, ...)
+
+
+print("Loading NerubArPalace")
+
+function NerubArPalace:OnEnable()
+    print("NerubArPalace:OnEnable")
+    local instance = addon.Items:RegisterInstance(2292, 6, {3524})
+    ----- Ulgrax the Devourer
+    local bossLoot = {
+        infoId = 2607,
+        instanceId = instance.id,
+        items = {
+            212388, --Ulgrax's Morsel-Masher
+            212409, --Venom-Etched Claw
+            212386, --Husk of Swallowing Darkness
+            212428, --Final Meal's Horns
+            212424, --Seasoned Earthen Boulderplates
+            212446, --Royal Emblem of Nerub-ar
+            212419, --Bile-Soaked Harness
+            212426, --Crunchy Intruder's Wristband
+            212425, --Devourer's Taut Innards
+            212442, --Greatbelt of the Hungerer
+            212423, --Rebel's Drained Marrowslacks
+            212431, --Undermoth-Lined Footpads
+            219915  --Foul Behemoth's Chelicera
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- The Bloodbound Horror
+    bossLoot = {
+        infoId = 2611,
+        instanceId = instance.id,
+        items = {
+            212395, --Blood-Kissed Kukri
+            212404, --Scepter of Manifested Miasma
+            212417, --Beyond's Dark Visage
+            212439, --Beacons of the False Dawn
+            212421, --Goresplattered Membrane
+            212438, --Polluted Spectre's Wraps
+            212414, --Lost Watcher's Remains
+            212430, --Shattered Eye Cincture
+            212422, --Bloodbound Horror's Legplates
+            225590, --Boots of the Black Bulwark
+            212447, --Key to the Unseeming
+            212451, --Aberrant Spellforge
+            219917  --Creeping Coagulum
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Sikran, Captain of the Sureki
+    bossLoot = {
+        infoId = 2599,
+        instanceId = instance.id,
+        items = {
+            225618, --Dreadful Stalwart's Emblem
+            225619, --Mystic Stalwart's Emblem
+            223097, --Pattern: Adrenal Surge Clasp
+            225620, --Venerated Stalwart's Emblem
+            225621, --Zenith Stalwart's Emblem
+            212413, --Honored Executioner's Perforator
+            212392, --Duelist's Dancing Steel
+            212405, --Flawless Phase Blade
+            212399, --Splintershot Silkbow
+            212427, --Visor of the Ascended Captain
+            225577, --Sureki Zealot's Insignia
+            212415, --Throne Defender's Bangles
+            212445, --Chitin-Spiked Jackboots
+            212416, --Cosmic-Tinged Treads
+            212449, --Sikran's Endless Arsenal
+            -- Tier Set Hands
+            211985, --Warrior Hands
+            211994, --Paladin Hands
+            212003, --Death Knight Hands
+            212012, --Shaman Hands
+            212021, --Hunter Hands
+            212030, --Evoker Hands
+            212039, --Rogue Hands
+            212048, --Monk Hands
+            212057, --Druid Hands
+            212066, --Demon Hunter Hands
+            212075, --Warlock Hands
+            212084, --Priest Hands
+            212093  --Mage Hands
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Rasha'nan
+    bossLoot = {
+        infoId = 2609,
+        instanceId = instance.id,
+        items = {
+            225630, --Dreadful Obscenity's Idol
+            225631, --Mystic Obscenity's Idol
+            224435, --Pattern: Duskthread Lining
+            225632, --Venerated Obscenity's Idol
+            225633, --Zenith Obscenity's Idol
+            212398, --Bludgeons of Blistering Wind
+            212391, --Predator's Feasthooks
+            212440, --Devotee's Discarded Headdress
+            212448, --Locket of Broken Memories
+            225574, --Wings of Shattered Sorrow
+            212437, --Ravaged Lamplighter's Manacles
+            225583, --Behemoth's Eroded Cinch
+            225586, --Rasha'nan's Grotesque Talons
+            212453, --Skyterror's Corrosive Organ
+            -- Tier Set Shoulder
+            211982, --Warrior Shoulder
+            211991, --Paladin Shoulder
+            212000, --Death Knight Shoulder
+            212009, --Shaman Shoulder
+            212018, --Hunter Shoulder
+            212027, --Evoker Shoulder
+            212036, --Rogue Shoulder
+            212045, --Monk Shoulder
+            212054, --Druid Shoulder
+            212063, --Demon Hunter Shoulder
+            212072, --Warlock Shoulder
+            212081, --Priest Shoulder
+            212090  --Mage Shoulder
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Broodtwister Ovi'nax
+    bossLoot = {
+        infoId = 2612,
+        instanceId = instance.id,
+        items = {
+            225614, --Dreadful Blasphemer's Effigy
+            225615, --Mystic Blasphemer's Effigy
+            226190, --Recipe: Sticky Sweet Treat
+            225616, --Venerated Blasphemer's Effigy
+            225617, --Zenith Blasphemer's Effigy
+            212389, --Spire of Transfused Horrors
+            212387, --Broodtwister's Grim Catalyst
+            225588, --Sanguine Experiment's Bandages
+            212418, --Black Blood Injectors
+            225580, --Accelerated Ascension Coil
+            225582, --Assimilated Eggshell Slippers
+            225576, --Writhing Ringworm
+            212452, --Gruesome Syringe
+            220305, --Ovi'nax's Mercurial Egg
+            -- Tier Set Chest
+            211987, --Warrior Chest
+            211996, --Paladin Chest
+            212005, --Death Knight Chest
+            212014, --Shaman Chest
+            212023, --Hunter Chest
+            212032, --Evoker Chest
+            212041, --Rogue Chest
+            212050, --Monk Chest
+            212059, --Druid Chest
+            212068, --Demon Hunter Chest
+            212077, --Warlock Chest
+            212086, --Priest Chest
+            212095  --Mage Chest
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Nexus-Princess Ky'veza
+    bossLoot = {
+        infoId = 2601,
+        instanceId = instance.id,
+        items = {
+            225626, --Dreadful Slayer's Icon
+            225627, --Mystic Slayer's Icon
+            223048, --Plans: Siphoning Stiletto
+            225628, --Venerated Slayer's Icon
+            225629, --Zenith Slayer's Icon
+            225636, --Regicide
+            219877, --Void Reaper's Warp Blade
+            212400, --Shade-Touched Silencer
+            225581, --Ky'veza's Covert Clasps
+            212441, --Bindings of the Starless Night
+            225589, --Nether Bounty's Greatbelt
+            225591, --Fleeting Massacre Footpads
+            221023, --Treacherous Transmitter
+            212456, --Void Reaper's Contract
+            -- Tier Set Legs
+            211983, --Warrior Legs
+            211992, --Paladin Legs
+            212001, --Death Knight Legs
+            212010, --Shaman Legs
+            212019, --Hunter Legs
+            212028, --Evoker Legs
+            212037, --Rogue Legs
+            212046, --Monk Legs
+            212055, --Druid Legs
+            212064, --Demon Hunter Legs
+            212073, --Warlock Legs
+            212082, --Priest Legs
+            212091  --Mage Legs
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- The Silken Court
+    bossLoot = {
+        infoId = 2608,
+        instanceId = instance.id,
+        items = {
+            223094, --Design: Magnificent Jeweler's Setting
+            225622, --Dreadful Conniver's Badge
+            225623, --Mystic Conniver's Badge
+            225624, --Venerated Conniver's Badge
+            225625, --Zenith Conniver's Badge
+            212407, --Anub'arash's Colossal Mandible
+            212397, --Takazj's Entropic Edict
+            225575, --Silken Advisor's Favor
+            212429, --Whispering Voidlight Spaulders
+            225584, --Skeinspinner's Duplicitous Cuffs
+            212432, --Thousand-Scar Impalers
+            212443, --Shattershell Greaves
+            220202, --Spymaster's Web
+            212450  --Swarmlord's Authority
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Queen Ansurek
+    bossLoot = {
+        infoId = 2602,
+        instanceId = instance.id,
+        items = {
+            223144, --Formula: Enchant Weapon - Authority of the Depths
+            224151, --Reins of the Ascendant Skyrazor
+            224147, --Reins of the Sureki Skyrazor
+            225634, --Web-Wrapped Curio
+            212401, --Ansurek's Final Judgment
+            212394, --Sovereign's Disdain
+            225579, --Crest of the Caustic Despot
+            212444, --Frame of Felled Insurgents
+            212433, --Omnivore's Venomous Camouflage
+            212420, --Queensguard Carapace
+            225587, --Devoted Offering's Irons
+            212436, --Clutches of Paranoia
+            225585, --Acrid Ascendant's Sash
+            212435, --Liquified Defector's Leggings
+            212434, --Voidspoken Sarong
+            225578, --Seal of the Poisoned Pact
+            212454, --Mad Queen's Mandate
+            -- Tier Set Head
+            211984, --Warrior Head
+            211993, --Paladin Head
+            212002, --Death Knight Head
+            212011, --Shaman Head
+            212020, --Hunter Head
+            212029, --Evoker Head
+            212038, --Rogue Head
+            212047, --Monk Head
+            212056, --Druid Head
+            212065, --Demon Hunter Head
+            212074, --Warlock Head
+            212083, --Priest Head
+            212092  --Mage Head
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+end

--- a/Items/TwwS2.lua
+++ b/Items/TwwS2.lua
@@ -1,0 +1,565 @@
+local TwwS2 = LibStub("AceAddon-3.0"):GetAddon("AlterEgo"):NewModule("TwwS2")
+local tocVersion = select(1, GetBuildInfo())
+
+if tocVersion <= "11.0.2" then
+    return
+end
+
+print("TwwS2 loaded")
+
+---@class AE_Addon
+local addon = select(2, ...)
+
+-- Extract from BestInSlotRedux, where to retrieve it ?
+local bonusesBfa = {11359,11996,9639,6646}
+local bonusesBfa2 = {10067,11996,9639,6646}
+local bonusesSl = {9987,11996,9639,6646}
+local bonusesTwwS2a = {3170,11996,9639,6646}
+local bonusesTwwS2b = {5900,11996,9639,6646}
+
+function TwwS2:OnEnable()
+    print("TwwS2:OnEnable")
+    self:TheaterOfPain()
+    self:OperationMechagon()
+    self:TheMOTHERLODE()
+    self:TheRookery()
+    self:DarkflameCleft()
+    self:CinderbrewMeadery()
+    self:PrioryOfTheSacredFlame()
+    self:OperationFloodgate()
+end
+
+function TwwS2:TheaterOfPain()
+    local instance = addon.Items:RegisterInstance(1683, 8, bonusesSl)
+    ----- An Affront of Challengers
+    local bossLoot = {
+        infoId = 2397,
+        instanceId = instance.id,
+        items = {
+            178866, --Dessia's Decimating Decapitator
+            178799, --Amphitheater Stalker's Hood
+            178803, --Plague-Licked Amice
+            178795, --Vest of Concealed Secrets
+            178800, --Galvanized Oxxein Legguards
+            178871, --Bloodoath Signet
+            178810  --Vial of Spectral Essence
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+     ----- Gorechop
+    bossLoot = {
+        infoId = 2401,
+        instanceId = instance.id,
+        items = {
+            178793, --Abdominal Securing Chestguard
+            178806, --Contaminated Gauze Wristwraps
+            178798, --Grips of OVerwhelming Beatings
+            178869, --Fleshfused Circle
+            178808  --Viscera of Coalesced Hatred
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Xav the Unfallen
+    bossLoot = {
+        infoId = 2390,
+        instanceId = instance.id,
+        items = {
+            178865, --Xav's Pike of Authority
+            178789, --Fleshcrafter's Knife
+            178864, --Gorebound Predator's Gavel
+            178863, --Gorestained Cleaver
+            178794, --Triumphant Combatatnt's Chainmail
+            178807, --Pit FFighter's Wristguards
+            178801  --Fearless Challenger's Leggings
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Kul'Tharok
+    bossLoot = {
+        infoId = 2389,
+        instanceId = instance.id,
+        items = {
+            178792, --Soulswen Vestments
+            178805, --Girdle of Shattered Dreams
+            178796, --Boots of Shuddering Matter
+            178870, --Ritual Bone Band
+            178809  --Soulletting Ruby
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Mordretha, the Endless Empress
+    bossLoot = {
+        infoId = 2417,
+        instanceId = instance.id,
+        items = {
+            178867, --Barricade of the Endless Empire
+            178868, --Deathwalker's Promise
+            178802, --Unyielding Combatatn's Pauldrons
+            178804, --Fallen Empress's Cord
+            178797, --Vanquished Usurper's Footpads
+            178872, --Ring of Perpetual Conflict
+            178811  --Grim Codex
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:OperationMechagon()
+    local instance = addon.Items:RegisterInstance(1490, 8, bonusesBfa2)
+  
+    ----- Tussle Tonks
+    local bossLoot = {
+        infoId = 2336,
+        instanceId = instance.id,
+        items = {
+            168958, --Ringmaster's Cummerbund
+            168965, --Modular Platinum Plating
+            168964, --Hyperthread Boots
+            168962, --Apex Perforator
+            168966, --Heavy Alloy Legplates
+            168957, --Mekgineer's Championship Belt
+            168955, --Electrifying Cognitive Amplifier
+            168967, --Gold-Coated Superconductors
+            170510  --Forceful Logic Board
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- K.U.-J.0.
+    bossLoot = {
+        infoId = 2339,
+        instanceId = instance.id,
+        items = {
+            168969, --Operator's Mitts
+            168970, --Trashmaster's Mantle
+            168972, --Pyroclastic Greatboots
+            168971, --Swift Pneumatic Grips
+            168968, --Flame-Seared Leggings
+            170508  --Optimized Logic Board
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Machinist's Garden
+    bossLoot = {
+        infoId = 2348,
+        instanceId = instance.id,
+        items = {
+            168975, --Machinist's Treasured Treads
+            168973, --Neural Synapse Enhancer
+            168974, --Self-Repairing Cuisses
+            168976, --Automatic Waist Tightener
+            169159, --Overclocking Bit Band
+            169160, --Shorting Bit Band
+            168977, --Rebooting Bit Band
+            169161, --Protecting Bit Band
+            169344, --Ingenious Mana Battery
+            169608, --Tearing Sawtooth Blade
+            170507, --Omnipurpose Logic Board
+            167556  --Subroutine: Overclock
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- King Mechagon
+    bossLoot = {
+        infoId = 2331,
+        instanceId = instance.id,
+        items = {
+            168980, --Gauntlets of Absolute Authority
+            168986, --Mad King's Sporran
+            168983, --Maniacal Monarch's Girdle
+            168985, --Self-Sanitizing Handwraps
+            168989, --Hyperthread Wristwraps
+            168988, --Royal Attendant's Trousers
+            168982, --Regal Mekanospurs
+            168978, --Anodized Deflectors
+            168671, --Electromagnetic Resistors
+            169378, --Golden Snorf
+            169774, --Progression Sprocket
+            168842, --Engine of Mecha-Perfection
+            169172, --Blueprint: Perfectly Timed Differential
+            170509  --Performant Logic Board
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:TheMOTHERLODE()
+    local instance = addon.Items:RegisterInstance(1010, 8, bonusesBfa)
+ 
+    ----- Coin-Operated Crowd Pummeler
+    local bossLoot = {
+        infoId = 2109,
+        instanceId = instance.id,
+        items = {
+            159638, --Electro-Arm Bludgeoner
+            159357, --Linked Pummeler Grips
+            158350, --Rowdy Reveler's Legwraps
+            159663, --G0-4W4Y Crowd Repeller
+            155864, --Power-Assisted Vicegrips
+            159462, --Footbomb Championship Ring
+            158353  --Servo-Arm Bindings
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Azerokk
+    bossLoot = {
+        infoId = 2114,
+        instanceId = instance.id,
+        items = {
+            159612, --Azerokk's Resonating Heart
+            159231, --Mine Rat's Handwarmers
+            159226, --Excavator's Safety Belt
+            159336, --Mercenary Miner's Boots
+            159725, --Unscrupulous Geologist's Belt
+            158357, --Bindings of Enraged Earth
+            158359, --Stonefury Vambraces
+            159679, --Sabatons of Rampaging Elements
+            159361  --Shalebiter Interlinked Chain
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Rixxa Fluxflame
+    bossLoot = {
+        infoId = 2115,
+        instanceId = instance.id,
+        items = {
+            159639, --P.A.C.I.F.I.S.T. Mk7
+            159235, --Deranged Alchemist's Slippers
+            159240, --Rixxa's Sweat-Wicking Cuffs
+            159287, --Cloak of Questionable Intent
+            159451, --Leadplate Legguards
+            158341, --Chemical Blaster's Legguards
+            159305  --Corrosive Handler's Gloves
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Mogul Razdunk
+    bossLoot = {
+        infoId = 2116,
+        instanceId = instance.id,
+        items = {
+            161135, --Schematic: Mecha-Mogul Mk2
+            159415, --Skyscorcher Pauldrons
+            159298, --Venture Co. Plenipotentiary Vest
+            158364, --High Altitude Turban
+            159360, --Crashguard Spaulders
+            159611, --Razdunk's Big Red Button
+            158307, --Shrapnel-Dampening Chestguard
+            159232, --Exquisitely Aerodynamic Shoulderpads
+            158349, --Petticoat of the Self-Stylized Azerite Baron
+            159641  --G3T-00t
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:TheRookery()
+    print("Registering The Rookery 2316")
+    local instance = addon.Items:RegisterInstance(2316, 8, bonusesTwwS2a)
+
+    ----- Kyrioss
+    local bossLoot = {
+        infoId = 2566,
+        instanceId = instance.id,
+        items = {
+            221032, --Aufgeladener Sturmrufer
+            221033, --Hyperaktive Sturmklaue
+            221037, --Geladene Krähenfederwickel
+            221036, --Gewitterwindgreifhandschuhe
+            221034, --Donnerbeschlagene Beinschützer
+            221035, --Treter des galvanischen Himmelsseglers
+            219294  --Energiegeladene Sturmkrähenfeder
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Sturmwache Gorren
+    bossLoot = {
+        infoId = 2567,
+        instanceId = instance.id,
+        items = {
+            221038, --Grollender Donnerhammer
+            221039, --Zornbesetzter Sturmbogen
+            221045, --Sturmbrecherbollwerk
+            221041, --Rüstung des Blitzbrechers
+            221040, --Blitzableiterbänder
+            221042, --Kilt des Windreiters
+            221043, --Sohlen des Wolkenwanderers
+            219295  --Siegel der algarischen Einigkeit
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Voidstone Monstrosity
+    bossLoot = {
+        infoId = 2568,
+        instanceId = instance.id,
+        items = {
+            221046, --Kniebrecherbehemoth
+            221044, --Schattendolch des Kolosses
+            221047, --Starren des Monstrums
+            221048, --Amicia des Vergessens
+            221049, --Wams des erweckten Steins
+            221050, --Uralte gehärtete Beinwickel
+            221197, --Reif des Verseuchten
+            219296  --Entropischer Skardynkern
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:DarkflameCleft()
+    local instance = addon.Items:RegisterInstance(2303, 8, bonusesTwwS2a)
+    
+    ----- Old Waxbeard
+    local bossLoot = {
+        infoId = 2569,
+        instanceId = instance.id,
+        items = {
+            221096, --Rail Rider's Slicer
+            221097, --Arcane Bucket
+            221098, --Mole Knight's Soot Armor
+            221099, --Wick's Golden Loop
+            219304  --Wagon Driver's Wax Whistle
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Lohenzar
+    bossLoot = {
+        infoId = 2559,
+        instanceId = instance.id,
+        items = {
+            221100, --Waxsteel Great Helm
+            221103, --Flickering Light Collar
+            221104, --Twilight Wax Bindings
+            221102, --Shimmering Ember Claws
+            221101, --Strongly Scented Candlewick
+            219305  --Decorated Lohenzar Wax
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- The Candle King
+    bossLoot = {
+        infoId = 2560,
+        instanceId = instance.id,
+        items = {
+            221105, --Darkzone Decapitator
+            221109, --Candle Bearer's Veil
+            221108, --King's Malicious Grips
+            221107, --Twilight Keeper's Belt Buckle
+            221106, --Dusk Stomper's Sabatons
+            219306  --Candle King's Stylus
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- The Darkness
+    bossLoot = {
+        infoId = 2561,
+        instanceId = instance.id,
+        items = {
+            225548, --Wick's Leash
+            221111, --Poleaxe of Dark Fate
+            221110, --Crepuscular Carver
+            221113, --Twilight Visage
+            221115, --Light-Shy Amice
+            221112, --Dark Buckle Fists
+            221114, --Shadow Brood Leggings
+            219307  --Fragment of Darkness
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:CinderbrewMeadery()
+    local instance = addon.Items:RegisterInstance(2335, 8, bonusesTwwS2a)
+    
+    ----- Brewmaster Aldryr
+    local bossLoot = {
+        infoId = 2586,
+        instanceId = instance.id,
+        items = {
+            221051, --Shatterer of the Shaken
+            221052, --Foam-Filled Pauldrons
+            221054, --Chef Nager's Towel
+            221053, --Battle-Marked Gauntlets
+            219297  --Cinderbrew Mug
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- I'pa
+    bossLoot = {
+        infoId = 2587,
+        instanceId = instance.id,
+        items = {
+            221057, --Sticky Stirring Rod
+            221056, --Vessel of the Drink
+            221055, --Cinderbrew-Soaked Cowl
+            221060, --Rescue Barrel Collar
+            221059, --I'pa's Pale Beer Guards
+            221058, --Brewmaster's Belt
+            221061  --Hop-Laden Great Boots
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Benk Buzzbrew
+    bossLoot = {
+        infoId = 2588,
+        instanceId = instance.id,
+        items = {
+            221063, --Swarm Breaker's Ladle
+            221062, --Treacherous Blade of the Seething Queen-maker
+            221201, --Fireproof Ember Bee Perch
+            221064, --Fluffy Ember Cuffs
+            221067, --Punctured Beekeeper's Gloves
+            221065, --Pollen Catcher's Treads
+            219298  --Voracious Honey Buzzer
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Goldie Barontasch
+    bossLoot = {
+        infoId = 2589,
+        instanceId = instance.id,
+        items = {
+            221068, --Profit Splitter
+            221070, --"Azeroth's Best C.E.O" Cap
+            221072, --Profitable Business Coat
+            221069, --Cut-Resistant Business Breastplate
+            221071, --Wearing Boot Straps
+            221198, --Ring of 85 Years Service
+            219299  --Synergetic Brewterializer
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:PrioryOfTheSacredFlame()
+    local instance = addon.Items:RegisterInstance(2308, 8, bonusesTwwS2a)
+    
+    ----- Captain Screechwing
+    local bossLoot = {
+        infoId = 2571,
+        instanceId = instance.id,
+        items = {
+            221116, --Poleaxe of the Glorious Defender
+            221117, --Sanctified Priory Wall
+            221118, --Flame-Forged Armguards
+            221119, --Holy-Bound Hand Protection
+            221121, --Honor-Bound Follower's Sash
+            221120, --Boots of the Brave Guardian
+            219308  --Seal of the Priory
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Baron Brownspray
+    bossLoot = {
+        infoId = 2570,
+        instanceId = instance.id,
+        items = {
+            221122, --Hand of Beledar
+            221125, --Helm of the Righteous Crusade
+            221126, --Garments of the Fanatic Guardian
+            221124, --Bindings of the Blessed Baron
+            221123, --Devoted Plate Treads
+            219309  --Tome of Light's Devotion
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Prioress Murrbet
+    bossLoot = {
+        infoId = 2573,
+        instanceId = instance.id,
+        items = {
+            221127, --Emberfire Greatsword
+            221128, --Star-Forged Seraph's Mace
+            221131, --Elysian Flame Crown
+            221203, --Pyre-Forged Shoulderpieces of the Reviver
+            221130, --Seraphim Wraps of the Called
+            221129, --Divine Pyre Treads
+            221200, --Band of the Radiant Necromancer
+            219310  --Exploding Light Shard
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+
+function TwwS2:OperationFloodgate()
+    local instance = addon.Items:RegisterInstance(2387, 8, bonusesTwwS2b)
+    
+    ----- Big M.O.M.M.A.
+    local bossLoot = {
+        infoId = 2648,
+        instanceId = instance.id,
+        items = {
+            234491, --Ultrasonic BOOMerang
+            234500, --Mechanized Scrap Pauldrons
+            234503, --Hidden Projectiles of the Sky Stormer
+            234497, --Non-Conductive Murder Socks
+            232542  --Medi-Copter of the Void-Fused
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Demolition Duo
+    bossLoot = {
+        infoId = 2649,
+        instanceId = instance.id,
+        items = {
+            234492, --Keeza's R.D.F.F.E.K.
+            234498, --Waterworks Filtration Mask
+            234502, --Bront's Singed Blast Coat
+            234505, --Floodlight of the Venture Provider
+            232541  --Improvised Zephyrium Pacemaker
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Swampface
+    bossLoot = {
+        infoId = 2650,
+        instanceId = instance.id,
+        items = {
+            236768, --Crabboom
+            234494, --Gallytech Turbo Pin
+            234506, --Muck Diver's Plate Armor
+            234499, --Disturbed Seaweed Wraps
+            234495, --Blade Strangler's Pants
+            232543  --Resonating Ritual Muck
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+
+    ----- Giesel Gigashock
+    bossLoot = {
+        infoId = 2651,
+        instanceId = instance.id,
+        items = {
+            234490, --Circuit Breaker
+            234493, --Giesel's Manipulating Voltometer
+            234507, --Electrician's Suction Filter
+            234496, --Saboteur's Rubber Jacket
+            234504, --Scaffold Scraper's Jump Start
+            234501, --Portable Power Generator
+            232545  --Gigashock's Shock Cap
+        }
+    };
+    addon.Items:RegisterBossLoots(bossLoot)
+end
+

--- a/Items/TwwS2.lua
+++ b/Items/TwwS2.lua
@@ -5,8 +5,6 @@ if tocVersion <= "11.0.2" then
     return
 end
 
-print("TwwS2 loaded")
-
 ---@class AE_Addon
 local addon = select(2, ...)
 
@@ -18,7 +16,6 @@ local bonusesTwwS2a = {3170,11996,9639,6646}
 local bonusesTwwS2b = {5900,11996,9639,6646}
 
 function TwwS2:OnEnable()
-    print("TwwS2:OnEnable")
     self:TheaterOfPain()
     self:OperationMechagon()
     self:TheMOTHERLODE()
@@ -263,7 +260,6 @@ function TwwS2:TheMOTHERLODE()
 end
 
 function TwwS2:TheRookery()
-    print("Registering The Rookery 2316")
     local instance = addon.Items:RegisterInstance(2316, 8, bonusesTwwS2a)
 
     ----- Kyrioss

--- a/Table.lua
+++ b/Table.lua
@@ -191,7 +191,7 @@ function Table:New(config)
         function columnFrame:onClickHandler(f)
           rowFrame:onClickHandler(f)
           if column.onClick then
-            column:onClick(f)
+            column.onClick(f)
           end
         end
 

--- a/Utils.lua
+++ b/Utils.lua
@@ -64,7 +64,7 @@ end
 ---@param callback fun(value: T, index: number): boolean
 ---@return T|nil, number|nil
 function Utils:TableFind(tbl, callback)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableFind: Must be a table!")
   for i, v in ipairs(tbl) do
     if callback(v, i) then
       return v, i
@@ -80,7 +80,7 @@ end
 ---@param val any
 ---@return T|nil
 function Utils:TableGet(tbl, key, val)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableGet: Must be a table!")
   return self:TableFind(tbl, function(elm)
     return elm[key] and elm[key] == val
   end)
@@ -92,7 +92,7 @@ end
 ---@param callback fun(value: T, index: number): boolean
 ---@return T[]
 function Utils:TableFilter(tbl, callback)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableFilter: Must be a table!")
   local t = {}
   for i, v in pairs(tbl) do
     if callback(v, i) then
@@ -106,7 +106,7 @@ end
 ---@param tbl table
 ---@return number
 function Utils:TableCount(tbl)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableCount: Must be a table!")
   local n = 0
   for _ in pairs(tbl) do
     n = n + 1
@@ -120,7 +120,7 @@ end
 ---@param cache table?
 ---@return T[]
 function Utils:TableCopy(tbl, cache)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableCopy: Must be a table!")
   local t = {}
   cache = cache or {}
   cache[tbl] = t
@@ -140,7 +140,7 @@ end
 ---@param callback fun(value: T, index: number): any
 ---@return T[]
 function Utils:TableMap(tbl, callback)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableMap: Must be a table!")
   local t = {}
   self:TableForEach(tbl, function(v, k)
     local newv, newk = callback(v, k)
@@ -155,7 +155,7 @@ end
 ---@param callback fun(value: T, index: number)
 ---@return T[]
 function Utils:TableForEach(tbl, callback)
-  assert(type(tbl) == "table", "Must be a table!")
+  assert(type(tbl) == "table", "TableForEach: Must be a table!")
   for ik, iv in pairs(tbl) do
     callback(iv, ik)
   end
@@ -442,26 +442,3 @@ end
 --   frame:RenderScrollFrame()
 --   return frame
 -- end
-
-function Utils:CreateBisItemDropdown(columnFrame, character, slotID)
-  local frame = CreateFrame("Frame", "AlterEgoBisItem" .. character.info.name .. "Slot" .. slotID, columnFrame)
-  --local frame = addon.Utils:CreateScrollFrame({
-  --  name = "AlterEgoBisItem" .. character.info.name .. "Slot" .. slotID,
-  --  scrollSpeedVertical = 10,
-  --  height = 100,
-  --})
-  if frame ~= nil then
-    --frame:SetAllPoints()
-    --frame:SetMinResize(200, 200
-    frame:SetFrameStrata("TOOLTIP")
-    print("strata", frame:GetFrameStrata())
-    frame:SetHeight(20)
-    frame:SetPoint("TOPLEFT", columnFrame, "BOTTOMLEFT", 0, 0)
-    frame:SetPoint("TOPRIGHT", columnFrame, "BOTTOMRIGHT", 0, 0)
-    addon.Utils:SetBackgroundColor(frame, 1, 0, 0, 0.5)
-    frame:Hide()
-  else
-    print("Error nil frame !")
-  end
-  return frame
-end

--- a/Utils.lua
+++ b/Utils.lua
@@ -442,3 +442,26 @@ end
 --   frame:RenderScrollFrame()
 --   return frame
 -- end
+
+function Utils:CreateBisItemDropdown(columnFrame, character, slotID)
+  local frame = CreateFrame("Frame", "AlterEgoBisItem" .. character.info.name .. "Slot" .. slotID, columnFrame)
+  --local frame = addon.Utils:CreateScrollFrame({
+  --  name = "AlterEgoBisItem" .. character.info.name .. "Slot" .. slotID,
+  --  scrollSpeedVertical = 10,
+  --  height = 100,
+  --})
+  if frame ~= nil then
+    --frame:SetAllPoints()
+    --frame:SetMinResize(200, 200
+    frame:SetFrameStrata("TOOLTIP")
+    print("strata", frame:GetFrameStrata())
+    frame:SetHeight(20)
+    frame:SetPoint("TOPLEFT", columnFrame, "BOTTOMLEFT", 0, 0)
+    frame:SetPoint("TOPRIGHT", columnFrame, "BOTTOMRIGHT", 0, 0)
+    addon.Utils:SetBackgroundColor(frame, 1, 0, 0, 0.5)
+    frame:Hide()
+  else
+    print("Error nil frame !")
+  end
+  return frame
+end

--- a/Utils.lua
+++ b/Utils.lua
@@ -162,6 +162,22 @@ function Utils:TableForEach(tbl, callback)
   return tbl
 end
 
+---Check if a table contains a value
+---@generic T
+---@param tbl T[]
+---@param val T
+---@return boolean
+function Utils:TableContains(tbl, val)
+  assert(type(tbl) == "table", "TableContains: Must be a table!")
+  for _, v in pairs(tbl) do
+    if v == val then
+      return true
+    end
+  end
+
+  return false
+end
+
 ---Get character activity progress
 ---@param character AE_Character
 ---@return AE_CharacterVault|nil, AE_CharacterVault|nil


### PR DESCRIPTION
Hey there ! 

I've implemented a feature on your addon to track Best in Slot item progression on characters : 
- Added items of Nerubar, Liberation of Undermine & TWW S2 (Extract from best in slot redux)
- Added a new column on character window "Best In Slot"
- Ability to select an item for each slot to track progression from Aventurer 1 (0%) to Myth 6 (100%)
- Show global BIS progress on main frame. 

Happy to discuss if this could be merged to the official release :)

![image](https://github.com/user-attachments/assets/f2ab0eb3-d05b-4733-a7b5-8049272ee5a1)
![image](https://github.com/user-attachments/assets/0bbcf71c-16c5-4fd9-a625-15d38b231f62)

