### PR TITLE
Add shards of dundun as a tracked currency.

### DIFF
--- a/Database.lua
+++ b/Database.lua
@@ -443,6 +443,7 @@ Data.currencies = {
   {seasonID = 17, seasonDisplayID = 1, id = 3212, useTotalEarnedForMaxQty = true,  currencyType = "spark"},                    -- Radiant Spark Dust
   {seasonID = 17, seasonDisplayID = 1, id = 3310, useTotalEarnedForMaxQty = false, currencyType = "delve"},                    -- Coffer Key Shards
   {seasonID = 17, seasonDisplayID = 1, id = 3028, useTotalEarnedForMaxQty = false, currencyType = "delve"},                    -- Restored Coffer key
+  {seasonID = 17, seasonDisplayID = 1, id = 3376, useTotalEarnedForMaxQty = false,  currencyType = "shard"},                    -- Shard of DunDun
 }
 
 ---@type AE_Season[]

--- a/Modules/Main.lua
+++ b/Modules/Main.lua
@@ -2408,13 +2408,14 @@ function Module:Render()
             hasEarnedMax = true
           end
 
-          cellValue = tostring(charQuantity)
-          if addon.Data.db.global.currencies.showIcons then
-            cellValue = format("%s %s", infoIcon, cellValue)
+          if infoMaxWeeklyQuantity > 0 and infoMaxQuantity > 0 then
+            cellValue = format("%d (%d)", charQuantity, charEarnedThisWeek)
+          else
+            cellValue = tostring(charQuantity)
           end
 
-          if addon.Data.db.global.currencies.showMaxEarned and hasEarnedMax then
-            cellColor = DULL_RED_FONT_COLOR
+          if addon.Data.db.global.currencies.showIcons then
+            cellValue = format("%s %s", infoIcon, cellValue)
           end
 
           if charQuantity == 0 then
@@ -2422,6 +2423,10 @@ function Module:Render()
             if currency.currencyType == "crest" and charTotalEarned == 0 then
               cellValue = "-"
             end
+          end
+
+          if addon.Data.db.global.currencies.showMaxEarned and hasEarnedMax then
+            cellColor = DULL_RED_FONT_COLOR
           end
 
           currencyFrame.Text:SetText(cellColor:WrapTextInColorCode(cellValue))


### PR DESCRIPTION
Add display format for currencies that have a weekly maximum and a total maximum (this does not affect coffer key shards).  Re-order the earnt max and has 0 red / gray colouring such that the earned max colouring always applies, even after spending the currency.